### PR TITLE
fix(remove npmignore) : Remove npmignore due to transpilation issue

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.github/
-.vscode/
-dist/
-tests/
-src/index.js
-index.html
-webpack.config.js
-babel.config.js
-.eslintrc


### PR DESCRIPTION
Remove .npmignore due to transpilation error.

Due to some unknown reasons, .npmignore seems to be causing a problem with transpilation inside this npm package when being integrated with a react project 
